### PR TITLE
FIX:createAccountNotification&DashboardDeleteAccount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "react-router-dom": "^6.22.3",
         "redux": "^5.0.1",
         "sweetalert": "^2.1.2",
-        "sweetalert2": "^11.6.13"
+        "sweetalert2": "^11.10.7"
       },
       "devDependencies": {
         "@types/react": "^18.2.64",
@@ -3973,9 +3973,9 @@
       }
     },
     "node_modules/sweetalert2": {
-      "version": "11.6.13",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.6.13.tgz",
-      "integrity": "sha512-n5yVF0FNx1lm4XzpPyb1HIaiptzODfVyeCzmB809tpK+1bPdoKoevKOxYjrtId75DV7xuIp4r6cjn8xUAB8dPQ==",
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.7.tgz",
+      "integrity": "sha512-5Jlzrmaitay6KzU+2+LhYu9q+L4v/dZ8oZyEDH14ep0C/QilCnFLHmqAyD/Lhq/lm5DiwsOs6Tr58iv8k3wyGg==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/limonte"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-router-dom": "^6.22.3",
     "redux": "^5.0.1",
     "sweetalert": "^2.1.2",
-    "sweetalert2": "^11.6.13"
+    "sweetalert2": "^11.10.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",

--- a/src/routes/Dashboard.jsx
+++ b/src/routes/Dashboard.jsx
@@ -20,7 +20,7 @@ function Dashboard() {
       denyButtonText: `No`
     }).then((result) => {
       if (result.isConfirmed) {
-        const updatedAccounts = allAccounts.filter(account => account.email !== accountToDelete);
+        const updatedAccounts = allAccounts.filter(account => account.email !== email);
         const updatedAccountsString = JSON.stringify(updatedAccounts);
         localStorage.setItem('allAccounts', updatedAccountsString);
         setAllAccounts(updatedAccounts);

--- a/src/routes/createAccount.jsx
+++ b/src/routes/createAccount.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Swal from 'sweetalert2';
 
 export const CreateAccountForm = (props) => {
   const [nameError, setNameError] = useState(false);
@@ -25,6 +26,13 @@ export const CreateAccountForm = (props) => {
   const createAccount = () => {
     if (!validateName(firstName) || !validateName(lastName)) {
       setNameError(true);
+      Swal.fire({
+        position: "top-end",
+        icon: "success",
+        title: "Your work has been saved",
+        showConfirmButton: false,
+        timer: 1500
+      });
       return;
     }
 
@@ -53,6 +61,10 @@ export const CreateAccountForm = (props) => {
     localStorage.setItem("allAccounts", updatedAccountsString); // Store all accounts in a single array
     setAllAccounts(updatedAccounts);
     setCreatedAccount(accountData);
+    Swal.fire({
+      icon: "success",
+      title: "Account created successfully!",
+    });
     return accountData;
   };
 


### PR DESCRIPTION
Hey guys!

   Just made some adjustments in terms of when creating an account, a prompt or a 'sweet alert' must pop up. This has been added and also, I've also made some "tweaks" on the Dashboard in where deleting an account will be removed. Specifically on removing it from the dashboard and from the LocalStorage. Cause what I've noticed is that it's not being removed even though you've confirmed the deletion and I think it's because from the filter I made earlier in where from the Dashboard.jsx (const updateAccounts) line 23 it says !== accountToDelete. I think that's the reason on why the account from the table is not removed, so what I did is change the "accountToDelete" to "email" so it will be removed from both localStorage and Table. Please do review if I did it correctly before merging it, thank you team!